### PR TITLE
Street, district and distant maplets added

### DIFF
--- a/css/cyclestreets.css
+++ b/css/cyclestreets.css
@@ -175,3 +175,9 @@ td.left {
     margin: auto;
     padding: 10px;
 }
+
+img.maplet { 
+    width: 256px;
+    height: 256px;
+    border: 1px solid #eee;
+}

--- a/js/cyclestreets.js
+++ b/js/cyclestreets.js
@@ -259,8 +259,11 @@ function toTitleCase(str) {
 
 function getIndividualPhoto(photo_id, caption) {
     //console.log('getIndividualPhoto');
-    var photo_url = 'http://www.cyclestreets.net/location/';
-    photo_url += photo_id + '/cyclestreets'+ photo_id + '-size640.jpg';
+
+    // Maplets have this form:
+    // http://www.cyclestreets.net/location/34751/photomaplet34751zoom16.png
+    var mapletUrl = 'http://www.cyclestreets.net/location/' + photo_id + '/photomaplet'+ photo_id + 'zoom';
+
     var photo_title = 'Photo from CycleStreets';
     var photo_url = CS_API + 'photo.json';
     var photodata = {};
@@ -315,6 +318,12 @@ function getIndividualPhoto(photo_id, caption) {
                 $("a#permalink").attr("href", "http://www.cyclestreets.net/location/" + photo_id + "/");
                 $('#social_links').show();
                 $('#photo-caption').html(caption);
+
+	       // Street, district and distant maplets
+                $('#photomaplet16').attr({src: mapletUrl + '16.png'});
+                $('#photomaplet13').attr({src: mapletUrl + '13.png'});
+                $('#photomaplet10').attr({src: mapletUrl + '10.png'});
+
           } else {
               $('#photo-header').text('Sorry...');
               $('#photo-caption').html("Sorry, could not retrieve data for photo number " + photo_id + ".");

--- a/photomap/index.html
+++ b/photomap/index.html
@@ -63,6 +63,11 @@ $('#home').live('pagecreate',function(event){
 		    </p>
             <img src="/images/ajax-loader.gif" alt="Loading icon" id="loading-icon" />
             <img id="photo-image" alt="" class="hidden" />
+
+            <!-- Street, district and distant maplets -->
+            <img id="photomaplet16" class="maplet" alt="Street level map" />
+            <img id="photomaplet13" class="maplet" alt="District level map" />
+            <img id="photomaplet10" class="maplet" alt="Distant map" />
         </div>
     </div>
     


### PR DESCRIPTION
I've added 3 maplets which appear after the photo when a user taps on one of the icons on the 'Photos near me' view.

Maplets on the CycleStreets site have the form:

http://www.cyclestreets.net/location/34751/photomaplet34751zoom16.png

so the addition was quite simple. Three maplets are shown at street, district and distant zoom levels, which should be enough in most cases to help understand where the image was shown. They are always 256x256 .png files.

I have tested it on an HTC Widlfire by configuring my home network to use the code locally.
