### PR TITLE
Simple text changes for consistent terminology

### DIFF
--- a/journey/index.html
+++ b/journey/index.html
@@ -56,7 +56,7 @@ $('#home').live('pagecreate',function(event){
             </div>
             <span id="crosshairs" class="hidden"><img src="/images/small_crosshairs.png" alt="Crosshairs" id="crosshairs_img" /></span>
             <span id="marker-remove" data-role="button" data-icon="delete" data-iconpos="right" class="hidden">Remove start point</span>
-            <span id="marker-instructions" data-role="button" class="hidden">1. Click to set start</span>
+            <span id="marker-instructions" data-role="button" class="hidden">1. Tap to set start</span>
 <img src="/images/blue-dot.png" alt="Blue dot" class="hidden" />
 <img src="/images/cs_start.png" alt="Start marker" class="hidden" />
 <img src="/images/cs_finish.png" alt="Finish marker" class="hidden" />

--- a/js/cyclestreets.js
+++ b/js/cyclestreets.js
@@ -4,9 +4,9 @@ var CS_API = 'http://www.cyclestreets.net/api/';
 var global_page_type = null;
 
 // Route markers and instructions. 
-var SET_FIRST_MARKER = '1. Click to set start';
-var SET_SECOND_MARKER = '2. Click to set end';
-var COMPLETE_ROUTE = '3. Click to route';
+var SET_FIRST_MARKER = '1. Tap to set start';
+var SET_SECOND_MARKER = '2. Tap to set finish';
+var COMPLETE_ROUTE = '3. Tap to route';
 var start_marker = null;
 var finish_marker = null;
 var start_point = null;
@@ -1081,7 +1081,7 @@ if (window.google) {
                     $('#marker-instructions').show(); 
                     // Set up the 'remove marker' button.
                     $('#marker-remove').unbind('click');
-                    $('#marker-remove .ui-btn-text').text('Remove end point');
+                    $('#marker-remove .ui-btn-text').text('Remove finish point');
                     $('#marker-remove').show();
                     $('#marker-remove').click(function() { 
                         if (finish_point!==null) {


### PR DESCRIPTION
As described at:

https://github.com/cyclestreets/mobileweb/issues/43

this fixes:

end -> finish
click -> tap
