### PR TITLE
Fix the month off by one error for #29

### DIFF
--- a/js/cyclestreets.js
+++ b/js/cyclestreets.js
@@ -280,7 +280,7 @@ function getIndividualPhoto(photo_id, caption) {
                }
                var uploaded_by = data.result.username;
                var d = new Date(data.result.datetime*1000);
-               var uploaded_on = d.getDate() + "/" + d.getMonth() + "/" + d.getFullYear();
+               var uploaded_on = d.getDate() + "/" + (d.getMonth()+1) + "/" + d.getFullYear();
                // Get the best size to display the photo. 
                var live_sizes = data.result.thumbnailSizes;
                live_sizes = live_sizes.split("|").reverse();


### PR DESCRIPTION
Change needs tested.

The range returned by getMonth() is 0-11, thus you need to add one 
for display purposes. Based on 
https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/getMonth
