### PR TITLE
When “quietest” is selected, deselect other types.

### DIFF
--- a/js/cyclestreets.js
+++ b/js/cyclestreets.js
@@ -875,8 +875,7 @@ if (window.google) {
                         $("a#quietest").bind('tap', function(e){  
                             e.preventDefault();
                             $.mobile.showPageLoadingMsg();
-                            routeFromExistingItinerary(route_id,'quietest');
-                            return false; });
+                            routeFromExistingItinerary(route_id,'quietest');} );
                    }
                     global_page_type = "existing_route";
 


### PR DESCRIPTION
Fixes #59.
